### PR TITLE
Small improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,27 +54,8 @@
 			{
 				"command": "favoritesPanel.refreshPanel",
 				"title": "Refresh panel",
+				"category": "Favorites Panel",
 				"icon": "$(refresh)"
-			},
-			{
-				"command": "favoritesPanel.openFile",
-				"title": "Open File"
-			},
-			{
-				"command": "favoritesPanel.run",
-				"title": "Run Program"
-			},
-			{
-				"command": "favoritesPanel.openUrl",
-				"title": "Open URL"
-			},
-			{
-				"command": "favoritesPanel.runCommand",
-				"title": "Run Command"
-			},
-			{
-				"command": "favoritesPanel.insertNewCode",
-				"title": "Insert or replace text"
 			}
 		],
 		"viewsContainers": {
@@ -87,10 +68,12 @@
 			]
 		},
 		"views": {
-			"favoritesPanel": [
+			"explorer": [
 				{
 					"id": "favoritesPanel",
-					"name": ""
+					"name": "Favorites Panel",
+					"contextualTitle": "Favorites Panel",
+					"icon": "resources/favorites-panel.svg"
 				}
 			]
 		}


### PR DESCRIPTION
- When moving the view into the Explorer panel, on right-click, the favorites panel shows as an empty string.
- Most commands are not executable by users.

This fix renames the panel to "Favorites Panel". But this makes the panel name "Favorites Panel: Favorites Panel". So to fix that, I also moved the `view` into `explorer` instead of `favoritesPanel`. (I think this might change the default place for the panel into the Explorer instead of the Activity Bar. I'm not sure if this is what you want for default behavior but the panel can be still moved manually into the Activity Bar)

(Moving the panel into a panel other than the explorer or the activity bar still shows it as "Favorites Panel: Favorites Panel" which I think is fine.)

The other change: I removed most commands since they were meant to be used internally and users can't run them.
I also gave the `Reload panel` command a category.

![image](https://user-images.githubusercontent.com/8467416/131260511-f6a11e62-664e-4427-ae0c-c364daea41c2.png)
